### PR TITLE
Improve README with repo structure and build guidance

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,7 +1,7 @@
 ``` header
 @file: pd-wysheid/README.txt
 @author: madpang
-@date: [created: 2025-02-22, updated: 2025-08-12]
+@date: [created: 2025-02-22, updated: 2025-08-16]
 ```
 
 # pd-wysheid
@@ -16,6 +16,10 @@ The content is written in plain text, with markdown-style custom markup.
 It is converted to HTML using a custom-built converter (see [mmd2html](https://github.com/madpang/mmd2html)).
 
 ## Organization
+
+This repository includes two submodules:
+- `zettelkasten/`: the post manuscripts (plain text source).
+- `mmd2html/`: the plain text → HTML converter used by the build scripts.
 
 The folder structure of the project is as follows:
 ``` tree
@@ -43,6 +47,51 @@ The folder structure of the project is as follows:
 |- build-post.ps1 # script to build a single blog post
 |- build.ps1      # script to build blogs for the website
 |- scripts/       # utility scripts
+```
+
+## Branches & theme
+
+- `develop`: working branch used for content authoring and builds (contains `contents/` and build scripts).
+- `gh-pages`: deployment branch that hosts generated `artifacts/` for GitHub Pages.
+- `main`: stable source snapshot and repository overview.
+
+Theme-wise, the site is intentionally minimal and supports light/dark modes via a toggle in the header, backed by the shared CSS and a small theme-switcher script.
+
+## How to build
+
+The build workflow is PowerShell-based and uses the `mmd2html` converter.
+
+### Prerequisites
+- PowerShell 7+
+- Java (required to run the converter JAR)
+- The `mmd2html` and `zettelkasten` submodules initialized
+
+### Initialize submodules
+``` powershell
+git submodule update --init --recursive
+```
+
+### Build the converter
+Build the converter so the JAR exists at `./mmd2html/app/build/libs/mmd2html.jar` (see the submodule for exact build commands).
+
+### Build all posts (full site)
+``` powershell
+pwsh -NoProfile ./build.ps1
+```
+
+This runs the three-stage build:
+1. `scripts/prepare-build.ps1` compares `contents/` against `artifacts/` and prepares post lists.
+2. `scripts/export-build.ps1` calls `build-post.ps1` for every new/updated post.
+3. `scripts/deploy-build.ps1` copies `tmp-ws/artifacts/` into `artifacts/` (for `gh-pages`).
+
+### Build a single post
+``` powershell
+pwsh -NoProfile ./build-post.ps1 <path-to-output.html> <path-to-input.txt> ./commons/templates/post-template.html
+```
+
+Internally, the converter is invoked as:
+``` text
+java -jar ./mmd2html/app/build/libs/mmd2html.jar <input.txt> <output.html>
 ```
 
 ## License info.

--- a/README.txt
+++ b/README.txt
@@ -1,7 +1,7 @@
 ``` header
 @file: pd-wysheid/README.txt
 @author: madpang
-@date: [created: 2025-02-22, updated: 2025-08-16]
+@date: [created: 2025-02-22, updated: 2026-01-12]
 ```
 
 # pd-wysheid
@@ -49,46 +49,47 @@ The folder structure of the project is as follows:
 |- scripts/       # utility scripts
 ```
 
-## Branches & theme
+## Branches
 
 - `develop`: working branch used for content authoring and builds (contains `contents/` and build scripts).
 - `gh-pages`: deployment branch that hosts generated `artifacts/` for GitHub Pages.
 - `main`: stable source snapshot and repository overview.
 
-Theme-wise, the site is intentionally minimal and supports light/dark modes via a toggle in the header, backed by the shared CSS and a small theme-switcher script.
-
 ## How to build
 
-The build workflow is PowerShell-based and uses the `mmd2html` converter.
+The build workflow is **PowerShell**-based and uses the `mmd2html` converter.
 
 ### Prerequisites
+
 - PowerShell 7+
 - Java (required to run the converter JAR)
 - The `mmd2html` and `zettelkasten` submodules initialized
 
 ### Initialize submodules
+
 ``` powershell
 git submodule update --init --recursive
 ```
 
 ### Build the converter
+
 Build the converter so the JAR exists at `./mmd2html/app/build/libs/mmd2html.jar` (see the submodule for exact build commands).
 
 ### Build all posts (full site)
+
 ``` powershell
 pwsh -NoProfile ./build.ps1
 ```
-
 This runs the three-stage build:
 1. `scripts/prepare-build.ps1` compares `contents/` against `artifacts/` and prepares post lists.
 2. `scripts/export-build.ps1` calls `build-post.ps1` for every new/updated post.
 3. `scripts/deploy-build.ps1` copies `tmp-ws/artifacts/` into `artifacts/` (for `gh-pages`).
 
 ### Build a single post
+
 ``` powershell
 pwsh -NoProfile ./build-post.ps1 <path-to-output.html> <path-to-input.txt> ./commons/templates/post-template.html
 ```
-
 Internally, the converter is invoked as:
 ``` text
 java -jar ./mmd2html/app/build/libs/mmd2html.jar <input.txt> <output.html>
@@ -100,7 +101,5 @@ The CSS and JavaScript files are free to use, modify, and distribute.
 
 The content of those articles are the intellectual creation of the author, and are thus copyrighted.
 
-Note that, the font used in this site---called **Dinkie Bitmap**---is a product of [3type](https://3type.cn/fonts/dinkie_bitmap/index.html), if you want to use it, please purchase a license from their website.
-
-JetBrains Mono is used as the monospace font.
-It is an open-source font, and can be obtained from [GitHub](https://github.com/JetBrains/JetBrainsMono).
+[IBM Plex](https://www.ibm.com/plex/) series fonts are used as the primary typefaces.
+It is an open-source font family, and can be obtained from [GitHub](https://github.com/IBM/plex). 


### PR DESCRIPTION
### Motivation

- Make the repository README clearer by outlining the project structure and the two submodules used for content and conversion.
- Provide explicit build instructions so contributors can run the plain-text → HTML conversion locally and build posts.
- Explain branch roles used for GitHub Pages deployment and note the site theme toggle for clarity on appearance behavior.

### Description

- Updated `README.txt` to add a `Branches & theme` section and a `How to build` section with prerequisites and submodule notes.
- Documented the two submodules (`zettelkasten/` for manuscripts and `mmd2html/` for the converter) and included the `git submodule update --init --recursive` step.
- Added concrete build commands including full site build `pwsh -NoProfile ./build.ps1` and single-post build `pwsh -NoProfile ./build-post.ps1 <path-to-output.html> <path-to-input.txt> ./commons/templates/post-template.html`.
- Showed the internal converter invocation used by the build script as `java -jar ./mmd2html/app/build/libs/mmd2html.jar <input.txt> <output.html>`.

### Testing

- This is a documentation-only change and no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee21b726c8333b53c2d1dba79822c)