### PR TITLE
Sync commons from main into gh-pages during post deploy

### DIFF
--- a/.github/workflows/build-and-deploy-post.yml
+++ b/.github/workflows/build-and-deploy-post.yml
@@ -48,6 +48,7 @@ jobs:
         git show origin/main:scripts/deploy-build.ps1 > deploy-build.ps1
         pwsh -nop ./deploy-build.ps1
         git show origin/main:index.html > index.html
+        git checkout origin/main -- commons
     
     - name: Push the changes to gh-pages branch
       run: |


### PR DESCRIPTION
### Motivation
- Ensure shared static assets under `commons` (fonts, images, scripts, styles, templates) on `gh-pages` match `main` so resource changes are reflected after post deploy.
- The deployment branch (`gh-pages`) holds the `artifacts` directory while `main` holds the source, so copying `commons` at deploy time preserves consistent public assets.

### Description
- Added `git checkout origin/main -- commons` to `.github/workflows/build-and-deploy-post.yml` in the "Switch to gh-pages branch to collect build artifacts" step to copy the `commons` folder from `main` into `gh-pages` during deployment.
- This change copies the entire `commons` directory (fonts, images, scripts, styles, templates) so static resources are synchronized with the site HTML.
- To verify locally, run the build steps `pwsh -nop ./scripts/prepare-build.ps1` and `pwsh -nop ./scripts/export-build.ps1`, switch to `gh-pages`, run `git checkout main -- commons`, and confirm with `git diff main -- commons`.

### Testing
- No automated tests were run for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696579e7134083339d2ea0683b72c57c)