### PR TITLE
Limit deploy workflow to develop branch

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,70 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Seed artifacts for diff
+        run: |
+          if [ -d gh-pages/artifacts ]; then
+            mkdir -p artifacts
+            cp -a gh-pages/artifacts/. artifacts/
+          fi
+
+      - name: Build mmd2html converter (if needed)
+        run: |
+          if [ ! -f ./mmd2html/app/build/libs/mmd2html.jar ]; then
+            chmod +x ./mmd2html/gradlew
+            ./mmd2html/gradlew -p ./mmd2html build
+          fi
+
+      - name: Prepare build
+        run: pwsh -NoProfile ./scripts/prepare-build.ps1
+
+      - name: Export build
+        run: pwsh -NoProfile ./scripts/export-build.ps1
+
+      - name: Deploy artifacts into gh-pages
+        working-directory: gh-pages
+        run: |
+          rm -rf tmp-ws
+          cp -a ../tmp-ws ./tmp-ws
+          pwsh -NoProfile -File ../scripts/deploy-build.ps1
+
+      - name: Commit and push gh-pages
+        working-directory: gh-pages
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "Deploy site artifacts"
+            git push
+          else
+            echo "No changes to deploy."
+          fi


### PR DESCRIPTION
### Motivation
- Restrict automated deployments to the `develop` branch and allow manual runs to avoid triggering the deploy workflow from `main`.

### Description
- Remove `main` from the `push` branches list in `.github/workflows/build-and-deploy.yml` so the workflow triggers only on `develop` pushes and `workflow_dispatch`.

### Testing
- No automated tests were run because this change only updates a CI workflow file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968e59aa950833384367808be4c7a24)